### PR TITLE
feat: force catch up missed frames if too laggy

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "wasm": "wasm-pack build --features='wasm' --out-dir web/pkg",
+    "wasm": "wasm-pack build --features=wasm --out-dir web/pkg",
     "build": "npm run wasm && tsc && vite build",
     "preview": "vite preview --host"
   },

--- a/web/src/emulator.ts
+++ b/web/src/emulator.ts
@@ -10,6 +10,7 @@ class Emulator {
   private canvas: CanvasRenderingContext2D;
   private controllers: Controller[];
   private lastTimestamp = 0;
+  private maxCatchUp = 100;
   private audio?: AudioContext;
   private audioWorklet?: AudioWorkletNode;
 
@@ -75,7 +76,7 @@ class Emulator {
     if (!this.active) return;
   
     const deltaTime = timestamp - this.lastTimestamp;
-    let catchUpCount = Math.floor(deltaTime / frameDuration);
+    let catchUpCount = Math.min(this.maxCatchUp, Math.floor(deltaTime / frameDuration));
   
     while(catchUpCount--) {
       this.instance.stepFrame();

--- a/web/src/ringbuffer.ts
+++ b/web/src/ringbuffer.ts
@@ -12,12 +12,10 @@ class AudioRingBuffer {
   }
 
   enqueue(samples: Float32Array) {
-    if (this.writeLength() < samples.length) {
-      throw new Error("Ring buffer overflow");
-    }
+    const enqueuable = samples.subarray(0, this.writeLength());
 
-    for (let i = 0; i < samples.length; i++) {
-      this.buffer[this.writeIndex] = samples[i];
+    for (let i = 0; i < enqueuable.length; i++) {
+      this.buffer[this.writeIndex] = enqueuable[i];
       this.writeIndex = (this.writeIndex + 1) % this.capacity;
     }
   }


### PR DESCRIPTION
1. Handle the case when the delta time in between two call is very large.
The previous logic would have drew only 1 frame even if the delta time was, for example, 3 times bigger than the expected frame duration vs drawing current 1 + catching up the other 2s.
2. Add `maxCatchUp` (would be equal to 1 on the previous logic)
3. Also truncated the initial audio buffer (always larger at start for some reason?).